### PR TITLE
Add boot camps page

### DIFF
--- a/boot-camps/index.html
+++ b/boot-camps/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<head>
+<title>UW-Madison ACI Boot Camps</title>
+</head>
+<body>
+<h1>Boot Camps</h1>
+<h2>Data Carpentry</h2>
+<ul>
+<li><a href="https://uw-madison-aci.github.io/2017-01-10-uwmadison/">January 10-11, 2017</a></li>
+<li><a href="https://uw-madison-aci.github.io/2016-08-23-uwmadison/">August 23-24, 2016</a></li>
+<li><a href="https://uw-madison-aci.github.io/2016-06-01-uwmadison/">June 1-2, 2016</a></li>
+<li><a href="https://uw-madison-aci.github.io/2016-01-11-uwmadison/">January 11-12, 2016</a></li>
+</ul>
+<h2>Software Carpentry</h2>
+<ul>
+<li><a href="https://uw-madison-aci.github.io/2017-01-12-uwmadison/">January 12-13, 2017</a></li>
+<li><a href="https://uw-madison-aci.github.io/2016-08-29-uwmadison/">August 29-30, 2016</a></li>
+<li><a href="https://uw-madison-aci.github.io/2016-06-08-uwmadison/">June 8-9, 2016</a></li>
+<li><a href="https://uw-madison-aci.github.io/2016-01-14-uwmadison/">January 14-15, 2016</a></li>
+<li><a href="https://uw-madison-aci.github.io/2015-08-26-uw-madison/">August 26-27, 2015</a></li>
+<li><a href="https://uw-madison-aci.github.io/2015-06-03-wisc/">June 3-4, 2015</a></li>
+<li><a href="https://uw-madison-aci.github.io/2015-01-13-wisc/">January 13-16, 2015</a></li>
+<li><a href="https://uw-madison-aci.github.io/2014-08-25-wisc/">August 25-26, 2014</a></li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
Right now, the boot camps page at http://uw-madison-aci.github.io/ is nonexistent. This creates a page that lists all the prior boot camp websites available from the ACI GitHub repository.